### PR TITLE
feat : 라우터 기본 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
-    "react-router": "^7.8.1",
+    "react-router": "^7.8.2",
     "tailwind": "^4.0.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.12",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,13 @@
+import { RouterProvider } from 'react-router';
+import { routes } from './router/routes';
+import { Suspense } from 'react';
+
 function App() {
   return (
-    <>
-      <div>component</div>
-    </>
+    // TODO: loading component 넣기
+    <Suspense fallback={<div>로딩 중...</div>}>
+      <RouterProvider router={routes}></RouterProvider>
+    </Suspense>
   );
 }
 

--- a/src/pages/Auth/AuthLayout.tsx
+++ b/src/pages/Auth/AuthLayout.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router';
+
+function AuthLayout() {
+  return (
+    <div>
+      <Outlet></Outlet>
+    </div>
+  );
+}
+export default AuthLayout;

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -1,0 +1,4 @@
+function Login() {
+  return <div>Login</div>;
+}
+export default Login;

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -1,0 +1,4 @@
+function Register() {
+  return <div>Register</div>;
+}
+export default Register;

--- a/src/pages/Community/index.tsx
+++ b/src/pages/Community/index.tsx
@@ -1,0 +1,4 @@
+function Community() {
+  return <div>Community</div>;
+}
+export default Community;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,0 +1,4 @@
+function Home() {
+  return <h1>Main Page</h1>;
+}
+export default Home;

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -1,0 +1,4 @@
+function Mypage() {
+  return <div>Mypage</div>;
+}
+export default Mypage;

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,0 +1,10 @@
+function NotFound() {
+  return (
+    <h1>
+      존재하지 않는 페이지 입니다.
+      <br />
+      404 Not Found
+    </h1>
+  );
+}
+export default NotFound;

--- a/src/pages/Tarot/index.tsx
+++ b/src/pages/Tarot/index.tsx
@@ -1,0 +1,4 @@
+function Tarot() {
+  return <div>Tarot</div>;
+}
+export default Tarot;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,22 @@
+import { Outlet } from 'react-router';
+
+function Root() {
+  return (
+    <div>
+      <header>
+        {/* TODO: haeder component 넣기 */}
+        <h1>header</h1>
+      </header>
+
+      <main>
+        <Outlet></Outlet>
+      </main>
+
+      <footer>
+        {/* TODO: footer component 넣기 */}
+        <small> &copy; 2025 CTA </small>
+      </footer>
+    </div>
+  );
+}
+export default Root;

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,0 +1,85 @@
+import { createBrowserRouter } from 'react-router';
+import { lazy } from 'react';
+import AuthLayout from '@/pages/Auth/AuthLayout';
+
+const Root = lazy(() => import('@/pages'));
+const Home = lazy(() => import('@/pages/Home'));
+const Tarot = lazy(() => import('@/pages/Tarot'));
+const Community = lazy(() => import('@/pages/Community'));
+const Mypage = lazy(() => import('@/pages/Mypage'));
+const Login = lazy(() => import('@/pages/Auth/Login'));
+const Register = lazy(() => import('@/pages/Auth/Register'));
+const NotFound = lazy(() => import('@/pages/NotFound'));
+
+export const routes = createBrowserRouter([
+  {
+    path: '/',
+    Component: Root,
+    children: [
+      {
+        index: true,
+        Component: Home,
+        handle: { label: 'Home', showInNav: true },
+      },
+      {
+        path: 'tarot',
+        Component: Tarot,
+        handle: { label: 'Tarot', showInNav: true },
+      },
+      {
+        path: 'community',
+        Component: Community,
+        handle: { label: 'Community', showInNav: true },
+        loader: async () => {
+          // ex)
+          // const { data } = await supabase.from("테이블명").select("*");
+          // return data;
+          return true;
+        },
+      },
+      {
+        path: 'mypage',
+        Component: () => <Mypage />,
+        handle: { label: 'Mypage', showInNav: true },
+        loader: async () => {
+          // ex)
+          // const { data } = await supabase.from("테이블명").select("*");
+          // return data;
+          return true;
+        },
+      },
+
+      {
+        path: 'auth',
+        Component: AuthLayout,
+        children: [
+          {
+            path: 'login',
+            Component: Login,
+            handle: { label: 'Login', showInNav: true },
+            // action: async ({ request }) => {
+            // ex)
+            // const formData = await request.formData();
+            // const name = formData.get("name") as string;
+            // const email = formData.get("email") as string;
+            // TODO: supabase 통신
+            // },
+          },
+          {
+            path: 'register',
+            Component: Register,
+            handle: { label: 'Register', showInNav: true },
+            // action: async ({ request }) => {
+            // ex)
+            // const formData = await request.formData();
+            // const name = formData.get("name") as string;
+            // const email = formData.get("email") as string;
+            // TODO: supabase 통신
+            // },
+          },
+        ],
+      },
+    ],
+  },
+  { path: '*', Component: NotFound },
+]);


### PR DESCRIPTION
## ✅작업 개요
<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->
라우터 기본적인 설정을 한다

## ⭐ 작업 내용
<!-- 어떤 작업을 하였는지 체크박스 형식으로 적어주세요 -->
- [x] routes 기본 설정 - data mode
- [x] 라우터랑 연결되는 페이지 폴더, 기본 index.tsx 추가
- [x] header, footer, 404페이지 기본 구조 추가
- [x] 최상단 App 에 Suspense fallback 추가

## 😥 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->
Closes #6 

## 테스트 결과 보고
<!-- 테스트 결과나 내용 기입 -->
기본적인 설정만 해놨습니다. 주석의 코드는 이해를 돕기 위한 예시 코드라서 삭제하시고 사용하시면 됩니다.
AuthLayout 은 Login, Register 에서 공통 레이아웃 사용시 사용하시고, 필요 없으시면 역시 삭제하셔도 됩니다.
라우터랑 연결되는 페이지 폴더 파일들을 만들어 놓았습니다.