### PR TITLE
style : 공통 bg 컴포넌트 제작

### DIFF
--- a/src/common/components/Bg.tsx
+++ b/src/common/components/Bg.tsx
@@ -1,0 +1,17 @@
+type Props = { children?: React.ReactNode; className?: string };
+
+export default function Bg({ children, className }: Props) {
+  return (
+    <div
+      className={[
+        'relative w-full min-h-screen overflow-hidden',
+        'bg-[#0E0724]',
+        'bg-[radial-gradient(30.39%_56.9%_at_34.56%_-24.21%,rgba(255,174,23,0.35)_4.04%,rgba(255,174,23,0.12)_44.71%,rgba(255,174,23,0)_96.63%),radial-gradient(20.83%_37.04%_at_56.8%_107.13%,rgba(222,51,113,0.35)_0%,rgba(222,51,113,0.12)_53.37%,rgba(222,51,113,0)_100%),radial-gradient(44.58%_79.26%_at_26.33%_-9.17%,rgba(63,18,108,0.55)_0%,rgba(63,18,108,0.18)_55%,rgba(63,18,108,0)_100%),radial-gradient(33.93%_60.32%_at_78.49%_110.32%,rgba(222,51,113,0.9)_0%,rgba(222,51,113,0.22)_55%,rgba(222,51,113,0)_100%),linear-gradient(180deg,rgba(0,0,0,0)_0%,rgba(0,0,0,0.3)_100%)]',
+        'bg-no-repeat',
+        className ?? '',
+      ].join(' ')}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/common/layouts/Header.tsx
+++ b/src/common/layouts/Header.tsx
@@ -6,7 +6,7 @@ export default function Header() {
   const navList = extractNavItem(routes.routes);
 
   return (
-    <header className="sticky top-0 z-50 bg-[rgba(31,11,54,0.44)] text-main-white backdrop-blur-sm">
+    <header className="fixed inset-x-0 top-0 z-50 bg-[rgba(31,11,54,0.44)] text-main-white backdrop-blur-sm">
       <a
         href="#main"
         className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus:bg-main-white focus:text-black focus:px-3 focus:py-2 focus:rounded"

--- a/src/pages/Community/index.tsx
+++ b/src/pages/Community/index.tsx
@@ -1,4 +1,10 @@
+import Bg from '@/common/components/Bg';
+
 function Community() {
-  return <div>Community</div>;
+  return (
+    <Bg>
+      <section className="text-white">커뮤니티 리스트</section>
+    </Bg>
+  );
 }
 export default Community;


### PR DESCRIPTION
## ✅작업 개요
<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->
공통 bg 컴포넌트 제작

## ⭐ 작업 내용
<!-- 어떤 작업을 하였는지 체크박스 형식으로 적어주세요 -->
- [x] 공통 bg 컴포넌트 제작
- [x] 헤더 sticky -> fixed

## 😥 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->
Closes #17 

## 테스트 결과 보고
<!-- 테스트 결과나 내용 기입 -->
배경을 만들고, 반투명 헤더를 레이어 하기 위해 fixed 로 변경하였습니다.
각 페이지 컴포넌트에서 헤더의 높이만큼 padding-top 값을 주셔야 헤더에 가리지 않고 contents 가 나옵니다.