### PR TITLE
fix : 타로 스프레드 애니메이션 수정

### DIFF
--- a/src/pages/TarotSpreadDraw/components/Spread.tsx
+++ b/src/pages/TarotSpreadDraw/components/Spread.tsx
@@ -43,6 +43,8 @@ function Spread({ deck, cardWidth, transforms, slotRefs, resizeKey, onSnap, canA
   const [slotOfCard, setSlotOfCard] = useState<Array<number | null>>([]);
   const [flippedMain, setFlippedMain] = useState(false);
 
+  const animOnceRef = useRef(false);
+
   const slots = tarotStore((s) => s.slots);
   const setCard = tarotStore((s) => s.setCard);
   const setStage = tarotStore((s) => s.setStage);
@@ -559,6 +561,24 @@ function Spread({ deck, cardWidth, transforms, slotRefs, resizeKey, onSnap, canA
       document.body
     );
   }
+
+  useLayoutEffect(() => {
+    if (animOnceRef.current) return;
+    if (clarifyMode) return;
+    if (!orderedDeck.length) return;
+
+    const els = orderedDeck
+      .map((_, i) =>
+        slotOfCard[i] == null ? wrapsRef.current[i]?.querySelector('[data-anim]') : null
+      )
+      .filter(Boolean) as HTMLElement[];
+
+    if (!els.length) return;
+
+    animOnceRef.current = true;
+    gsap.set(els, { opacity: 0, y: 6 });
+    gsap.to(els, { opacity: 1, y: 0, duration: 0.36, ease: 'power2.out', stagger: 0.04 });
+  }, [orderedDeck, clarifyMode]);
 
   return (
     <>


### PR DESCRIPTION
## ✅작업 개요
타로 스프레드 페이지 애니메이션 수정

## ⭐ 작업 내용
- [x] 타로 카드 스프레드 애니메이션 수정

## 😥 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->

## 테스트 결과 보고
<!-- 테스트 결과나 내용 기입 -->